### PR TITLE
Add . to @INC in Build.PL

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use lib '.';
 use GvaScript_Builder;
 
 my $builder = GvaScript_Builder->new(


### PR DESCRIPTION
Perl 5.25.11 does not have . in the @INC path by default.
When 5.26.0 is released, the installer for this dist will
be broken.  This patch addreses this issue.